### PR TITLE
en spell service updated

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -20,7 +20,7 @@ var request = require('request');
  */
 function Api(ignored) {
   this.uris = {
-    'en': 'https://en.service.afterthedeadline.com',
+    'en': 'https://www.polishmywriting.com/proxy.php?url=',
     'fr': 'https://fr.service.afterthedeadline.com',
     'de': 'https://de.service.afterthedeadline.com',
     'pt': 'https://pt.service.afterthedeadline.com',

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -23,7 +23,7 @@ describe('Api', function() {
       var api = new Api;
 
       api.url().should.eql({
-        'en': 'https://en.service.afterthedeadline.com',
+        'en': 'https://www.polishmywriting.com/proxy.php?url=',
         'fr': 'https://fr.service.afterthedeadline.com',
         'de': 'https://de.service.afterthedeadline.com',
         'pt': 'https://pt.service.afterthedeadline.com',

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -48,7 +48,7 @@ describe('Api', function() {
       api.mock('request').and.replace(function(options, cb) {
         options.should.eql({
           method: 'POST',
-          url: 'https://en.service.afterthedeadline.com/checkDocument',
+          url: 'https://www.polishmywriting.com/proxy.php?url=/checkDocument',
           form: {data: data, key: key}
         });
         api.request.reset()


### PR DESCRIPTION
The previous service url seemed not to be working. Running the test would show no errors when there were clearly misspelled words. Tracked down this new service url that seems to be working for EN language.